### PR TITLE
fix for 'couchdb views are not copied during install'

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+global-include *.js

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     ],
     packages=find_packages(),
     namespace_packages=['openag', 'openag.brain', 'openag.brain.modules'],
+    include_package_data=True,
     install_requires=[
         'couchdb>=1.0.1',
         'flask>=0.10.1',


### PR DESCRIPTION
this should fix the issue of missing .js files containing CouchDb views during install